### PR TITLE
Update xposed_init to adapt the package name change in source files

### DIFF
--- a/app/src/main/assets/xposed_init
+++ b/app/src/main/assets/xposed_init
@@ -1,1 +1,1 @@
-com.devadvance.rootcloak.RootCloak
+com.devadvance.rootcloak2.RootCloak


### PR DESCRIPTION
Updated the package name from com.devadvance.rootcloak.RootCloak to com.devadvance.rootcloak2.RootCloak