### PR TITLE
Lower Xposed Min Version

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,10 +12,10 @@
             android:value="true" />
         <meta-data
             android:name="xposedminversion"
-            android:value="82" />
+            android:value="54" />
         <meta-data
             android:name="xposeddescription"
-            android:value="Hides root from chosen apps." />
+            android:value="@string/module_desc" />
 
         <activity
             android:name="com.devadvance.rootcloak2.SettingsActivity"

--- a/app/src/main/res/values-v14/styles.xml
+++ b/app/src/main/res/values-v14/styles.xml
@@ -5,7 +5,7 @@
         AppBaseTheme from BOTH res/values/styles.xml and
         res/values-v11/styles.xml on API 14+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light">
+    <style name="AppBaseTheme" parent="android:Theme.Holo">
         <!-- API 14 theme customizations can go here. -->
     </style>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
 
     <string name="app_name" translatable="false">RootCloak</string>
+    <string name="module_desc">Hides root from chosen apps.</string>
     <string name="action_new_app">Add App</string>
     <string name="action_new_keyword">Add Keyword</string>
     <string name="action_new_command">Add Command</string>


### PR DESCRIPTION
Devices (pre Lollipop) can have only Xposed framework 2.6/2.7 with Xposed Bridge cca 54, so 82 as min version makes them unsupported. Fix this.