### PR TITLE
Update RootCloak against RootBeer checks

### DIFF
--- a/app/src/main/java/com/devadvance/rootcloak2/DefaultLists.java
+++ b/app/src/main/java/com/devadvance/rootcloak2/DefaultLists.java
@@ -54,7 +54,7 @@ public class DefaultLists {
             "root", "busybox", "titanium",
             ".tmpsu", "su", "rootcloak2"};
 
-    public static final String[] DEFAULT_COMMAND_LIST = new String[]{"su", "which", "busybox", "pm", "am", "sh", "ps"};
+    public static final String[] DEFAULT_COMMAND_LIST = new String[]{"su", "which", "busybox", "pm", "am", "sh", "ps", "getprop"};
 
-    public static final String[] DEFAULT_LIBNAME_LIST = new String[]{"tool-checker"}; // RootBearNative
+    public static final String[] DEFAULT_LIBNAME_LIST = new String[]{}; // off
 }


### PR DESCRIPTION
- Remove tool-checker library hook as it cause crash.
- Add hook for RootBeerNative.checkForRoot() native method.
- Add hook for exec 'getprop' command.
- Update hook for SystemProperties.get("ro.build.selinux").