### PR TITLE
Additional Rootbeer overrides

### DIFF
--- a/app/src/main/java/com/devadvance/rootcloak2/DefaultLists.java
+++ b/app/src/main/java/com/devadvance/rootcloak2/DefaultLists.java
@@ -54,7 +54,7 @@ public class DefaultLists {
             "root", "busybox", "titanium",
             ".tmpsu", "su", "rootcloak2"};
 
-    public static final String[] DEFAULT_COMMAND_LIST = new String[]{"su", "which", "busybox", "pm", "am", "sh", "ps"};
+    public static final String[] DEFAULT_COMMAND_LIST = new String[]{"su", "which", "busybox", "pm", "am", "sh", "ps", "getprop"};
 
-    public static final String[] DEFAULT_LIBNAME_LIST = new String[]{"tool-checker"}; // RootBearNative
+    public static final String[] DEFAULT_LIBNAME_LIST = new String[]{}; // off
 }

--- a/app/src/main/java/com/devadvance/rootcloak2/RootCloak.java
+++ b/app/src/main/java/com/devadvance/rootcloak2/RootCloak.java
@@ -128,14 +128,124 @@ public class RootCloak implements IXposedHookLoadPackage {
             }
         });
 
-        // RootBear checkForRoot hook
+        // RootBeer hooks
+
         try {
             findAndHookMethod("com.scottyab.rootbeer.RootBeerNative", lpparam.classLoader, "checkForRoot",
                     Object[].class,
-                    new XC_MethodHook() {
+                    new XC_MethodReplacement() {
                         @Override
-                        public void beforeHookedMethod(MethodHookParam param) throws Throwable {
-                            param.setResult(0);
+                        protected Object replaceHookedMethod(MethodHookParam methodHookParam) throws Throwable {
+                            return false;
+                        }
+                    });
+        } catch (XposedHelpers.ClassNotFoundError e) {
+            e.printStackTrace();
+        }
+
+        try {
+            findAndHookMethod("com.scottyab.rootbeer.RootBeer", lpparam.classLoader, "detectRootManagementApps",
+                    new XC_MethodReplacement() {
+                        @Override
+                        protected Object replaceHookedMethod(MethodHookParam methodHookParam) throws Throwable {
+                            return false;
+                        }
+                    });
+        } catch (XposedHelpers.ClassNotFoundError e) {
+            e.printStackTrace();
+        }
+
+        try {
+            findAndHookMethod("com.scottyab.rootbeer.RootBeer", lpparam.classLoader, "detectPotentiallyDangerousApps",
+                    new XC_MethodReplacement() {
+                        @Override
+                        protected Object replaceHookedMethod(MethodHookParam methodHookParam) throws Throwable {
+                            return false;
+                        }
+                    });
+        } catch (XposedHelpers.ClassNotFoundError e) {
+            e.printStackTrace();
+        }
+
+        try {
+            findAndHookMethod("com.scottyab.rootbeer.RootBeer", lpparam.classLoader, "checkForBinary",
+                    String.class,
+                    new XC_MethodReplacement() {
+                        @Override
+                        protected Object replaceHookedMethod(MethodHookParam methodHookParam) throws Throwable {
+                            return false;
+                        }
+                    });
+        } catch (XposedHelpers.ClassNotFoundError e) {
+            e.printStackTrace();
+        }
+
+        try {
+            findAndHookMethod("com.scottyab.rootbeer.RootBeer", lpparam.classLoader, "checkForDangerousProps",
+                    new XC_MethodReplacement() {
+                        @Override
+                        protected Object replaceHookedMethod(MethodHookParam methodHookParam) throws Throwable {
+                            return false;
+                        }
+                    });
+        } catch (XposedHelpers.ClassNotFoundError e) {
+            e.printStackTrace();
+        }
+
+        try {
+            findAndHookMethod("com.scottyab.rootbeer.RootBeer", lpparam.classLoader, "checkForRWPaths",
+                    new XC_MethodReplacement() {
+                        @Override
+                        protected Object replaceHookedMethod(MethodHookParam methodHookParam) throws Throwable {
+                            return false;
+                        }
+                    });
+        } catch (XposedHelpers.ClassNotFoundError e) {
+            e.printStackTrace();
+        }
+
+        try {
+            findAndHookMethod("com.scottyab.rootbeer.RootBeer", lpparam.classLoader, "detectTestKeys",
+                    new XC_MethodReplacement() {
+                        @Override
+                        protected Object replaceHookedMethod(MethodHookParam methodHookParam) throws Throwable {
+                            return false;
+                        }
+                    });
+        } catch (XposedHelpers.ClassNotFoundError e) {
+            e.printStackTrace();
+        }
+
+        try {
+            findAndHookMethod("com.scottyab.rootbeer.RootBeer", lpparam.classLoader, "checkSuExists",
+                    new XC_MethodReplacement() {
+                        @Override
+                        protected Object replaceHookedMethod(MethodHookParam methodHookParam) throws Throwable {
+                            return false;
+                        }
+                    });
+        } catch (XposedHelpers.ClassNotFoundError e) {
+            e.printStackTrace();
+        }
+
+        try {
+            findAndHookMethod("com.scottyab.rootbeer.RootBeer", lpparam.classLoader, "checkForRootNative",
+                    new XC_MethodReplacement() {
+                        @Override
+                        protected Object replaceHookedMethod(MethodHookParam methodHookParam) throws Throwable {
+                            return false;
+                        }
+                    });
+        } catch (XposedHelpers.ClassNotFoundError e) {
+            e.printStackTrace();
+        }
+
+        try {
+            findAndHookMethod("com.scottyab.rootbeer.RootBeer", lpparam.classLoader, "detectRootCloakingApps",
+                    new XC_MethodReplacement() {
+                        @Override
+                        protected Object replaceHookedMethod(MethodHookParam methodHookParam) throws Throwable {
+                            return false;
                         }
                     });
         } catch (XposedHelpers.ClassNotFoundError e) {


### PR DESCRIPTION
- Adds additional public method overrides for RootBeer, which some app use directly instead of calling RootBeerNative.checkForRoot()
- Tested on my device against [RootBeer Sample](https://play.google.com/store/apps/details?id=com.scottyab.rootbeer.sample&hl=en), passes all tests