### PR TITLE
Separate message for denied root

### DIFF
--- a/app/src/main/java/com/devadvance/rootcloak2/NativeRootDetection.java
+++ b/app/src/main/java/com/devadvance/rootcloak2/NativeRootDetection.java
@@ -41,7 +41,7 @@ public class NativeRootDetection extends PreferenceActivity {
                 .setSharedPreferencesMode(MODE_WORLD_READABLE);
         addPreferencesFromResource(R.xml.native_root_detection);
         mPrefs = PreferenceManager.getDefaultSharedPreferences(this);
-        
+
         Preference uninstallLibrary = findPreference("uninstall_library");
         uninstallLibrary.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
@@ -74,7 +74,7 @@ public class NativeRootDetection extends PreferenceActivity {
 
         reloadAppsList();
     }
-    
+
     @Override
     protected void onResume() {
         mRootShell = new RootUtil();
@@ -85,7 +85,13 @@ public class NativeRootDetection extends PreferenceActivity {
     public void installLibrary() {
         String library = getApplicationInfo().nativeLibraryDir + File.separator + "librootcloak.so";
 
-        if (!mRootShell.isSU() || !new File(library).exists()) {
+        if (!mRootShell.isSU()) {
+            Toast.makeText(this, R.string.library_no_root, Toast.LENGTH_LONG).show();
+            finish();
+            return;
+        }
+
+        if (!new File(library).exists()) {
             Toast.makeText(this, R.string.library_installation_failed, Toast.LENGTH_LONG).show();
             finish();
             return;
@@ -189,7 +195,7 @@ public class NativeRootDetection extends PreferenceActivity {
                     Set<String> newSetting = (Set<String>) newValue;
                     oldSetting.removeAll(newSetting);
                     mPrefs.edit().putStringSet("reset_native_root_detection_apps", oldSetting).apply();
-                    
+
                     Intent refreshApps = new Intent(Common.REFRESH_APPS_INTENT);
                     sendBroadcast(refreshApps);
                     return true;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,5 +75,6 @@
     <string name="manage_keywords">Manage Keywords</string>
     <string name="manage_commands">Manage Commands</string>
     <string name="app_launcher_icon">App Launcher Icon</string>
+    <string name="library_no_root">Root permission denied</string>
 
 </resources>


### PR DESCRIPTION
As I didn't want to change too much, I just added the message "Root permission denied" instead of simply "installation failed". This would resolve #170.
This should help the user to understand the problem.